### PR TITLE
モックサーバーを使えるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@
 ```sh
 cd client && npm run gen-api
 ```
+
+## クライアント開発用のモックサーバーの立ち上げ
+```sh
+sh ./scripts/prism.sh
+```

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,6 +1,7 @@
 import { Apis, Configuration } from '@/api/generated'
 
-const api = new Apis(new Configuration({ basePath: '/api' }))
+// TODO: 開発環境と本番環境とでbasePathを分けられるようにする
+const api = new Apis(new Configuration({ basePath: 'http://localhost:4010' }))
 
 export default api
 export * from '@/api/generated'

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -28,12 +28,4 @@ const Header = () => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  return {
-    props: {
-      data: null,
-    },
-  }
-}
-
 export default Header

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,17 +1,40 @@
 import { Box } from '@mui/material'
-import type { NextPage } from 'next'
+import { AxiosError } from 'axios'
+import type { GetServerSideProps, NextPage } from 'next'
 import Link from 'next/link'
+import api from '@/api'
 import Header from '@/components/header'
 
-const Home: NextPage = () => {
+type Props = {
+  userName: string
+}
+
+const Home = (props: Props) => {
   return (
     <>
       <Header />
       <Box padding={4}>
+        ユーザー名 {props.userName}
         <Link href='/problems/sample-problem'>サンプル問題ページ</Link>
       </Box>
     </>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  let userName = ''
+  try {
+    const { data } = await api.getUsersMe()
+    userName = data.name
+  } catch (error) {
+    const err = error as AxiosError
+    console.log(err)
+  }
+  return {
+    props: {
+      userName: userName,
+    },
+  }
 }
 
 export default Home

--- a/scripts/prism.sh
+++ b/scripts/prism.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+docker run --init --rm \
+-v $(pwd)/schema/openapi:/tmp \
+-p 4010:4010 \
+stoplight/prism:4 mock \
+-h 0.0.0.0 \
+"/tmp/openapi.yaml"


### PR DESCRIPTION
以下のコマンドでモックサーバーのDockerコンテナが立ち上がる
```sh
sh ./scripts/prism.sh
```

生成したメソッドを使ってモックサーバーに対してのリクエストができることも確認済み

APIリクエストの書き方の例
https://github.com/dacq-trap/dacq/blob/bb77ed7a92fc5059badc024344dec273962bab65/client/src/pages/index.tsx#L24-L38