### PR TITLE
GitHub ActionsでのPR作成のためのworkaroundの対応

### DIFF
--- a/.github/workflows/openapi-generator.yaml
+++ b/.github/workflows/openapi-generator.yaml
@@ -29,8 +29,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.ACTIONS_SSH_PRIVATE_KEY }}
           commit-message: Regenerate with updated OpenAPI by GitHub Actions
-          branch: regenerate-openapi-
+          branch: regenerate-openapi
           branch-suffix: timestamp
           delete-branch: true
           title: Regenerate client codes with updated OpenAPI


### PR DESCRIPTION
原因
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs

採用した対処法
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys