### PR TITLE
モックサーバーへのリクエスト用にログイン状態を切り替えられるようにした

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.8.0",
         "axios": "^0.27.2",
         "next": "12.1.6",
+        "nookies": "^2.5.2",
         "react": "18.1.0",
         "react-dom": "18.1.0"
       },
@@ -2258,6 +2259,14 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/core-js-pure": {
       "version": "3.22.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.5.tgz",
@@ -4273,6 +4282,15 @@
       "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "peer": true
     },
+    "node_modules/nookies": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
+      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
+      "dependencies": {
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4952,6 +4970,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.0.tgz",
+      "integrity": "sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7045,6 +7068,11 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+    },
     "core-js-pure": {
       "version": "3.22.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.5.tgz",
@@ -8466,6 +8494,15 @@
       "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "peer": true
     },
+    "nookies": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
+      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
+      "requires": {
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8915,6 +8952,11 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "set-cookie-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.0.tgz",
+      "integrity": "sha512-cHMAtSXilfyBePduZEBVPTCftTQWz6ehWJD5YNUg4mqvRosrrjKbo4WS8JkB0/RxonMoohHm7cOGH60mDkRQ9w=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@mui/material": "^5.8.0",
     "axios": "^0.27.2",
     "next": "12.1.6",
+    "nookies": "^2.5.2",
     "react": "18.1.0",
     "react-dom": "18.1.0"
   },

--- a/client/src/api/requestOption.ts
+++ b/client/src/api/requestOption.ts
@@ -1,0 +1,12 @@
+import { AxiosRequestConfig } from 'axios'
+import { GetServerSidePropsContext } from 'next'
+
+export const requestOption = (
+  ctx: GetServerSidePropsContext
+): AxiosRequestConfig => {
+  return {
+    headers: ctx.req.headers.cookie
+      ? { cookie: ctx.req.headers.cookie }
+      : undefined,
+  }
+}

--- a/client/src/components/devLoginButton.tsx
+++ b/client/src/components/devLoginButton.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@mui/material'
-import { AxiosError } from 'axios'
-import api from '@/api'
+import { setCookie } from 'nookies'
 
 const DevLogin = () => {
   return (
@@ -16,12 +15,10 @@ const DevLogin = () => {
 }
 
 const onClickDevLogin = async () => {
-  try {
-    const { data } = await api.postOauthCode({ code: 'code-for-dev-login' })
-  } catch (error) {
-    const err = error as AxiosError
-    console.log(err)
-  }
+  setCookie(null, 'dq_session', 'session-code-for-dev-login', {
+    maxAge: 30 * 24 * 60 * 60,
+    path: '/',
+  })
 }
 
 export default DevLogin

--- a/client/src/components/devLoginButton.tsx
+++ b/client/src/components/devLoginButton.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@mui/material'
+import { AxiosError } from 'axios'
+import api from '@/api'
+
+const DevLogin = () => {
+  return (
+    <Button
+      variant='contained'
+      onClick={() => {
+        onClickDevLogin()
+      }}
+    >
+      Dev Login
+    </Button>
+  )
+}
+
+const onClickDevLogin = async () => {
+  try {
+    const { data } = await api.postOauthCode({ code: 'code-for-dev-login' })
+  } catch (error) {
+    const err = error as AxiosError
+    console.log(err)
+  }
+}
+
+export default DevLogin

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -1,6 +1,6 @@
 import { AppBar, Container, Toolbar, Typography } from '@mui/material'
-import { GetServerSideProps } from 'next'
 import Link from 'next/link'
+import DevLogin from './devLoginButton'
 
 const Header = () => {
   return (
@@ -22,6 +22,7 @@ const Header = () => {
               DacQ
             </Typography>
           </Link>
+          <DevLogin />
         </Toolbar>
       </Container>
     </AppBar>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material'
-import { AxiosError } from 'axios'
+import { AxiosError, AxiosRequestConfig } from 'axios'
 import type { GetServerSideProps, NextPage } from 'next'
 import Link from 'next/link'
 import api from '@/api'
@@ -26,7 +26,12 @@ const Home = (props: Props) => {
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   let userName = ''
   try {
-    const { data } = await api.getMe()
+    const option: AxiosRequestConfig = {
+      headers: ctx.req.headers.cookie
+        ? { cookie: ctx.req.headers.cookie }
+        : undefined,
+    }
+    const { data } = await api.getMe(option)
     userName = data.name
   } catch (error) {
     const err = error as AxiosError

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,8 +1,9 @@
 import { Box } from '@mui/material'
-import { AxiosError, AxiosRequestConfig } from 'axios'
+import { AxiosError } from 'axios'
 import type { GetServerSideProps, NextPage } from 'next'
 import Link from 'next/link'
 import api from '@/api'
+import { requestOption } from '@/api/requestOption'
 import Header from '@/components/header'
 
 type Props = {
@@ -26,12 +27,7 @@ const Home = (props: Props) => {
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   let userName = ''
   try {
-    const option: AxiosRequestConfig = {
-      headers: ctx.req.headers.cookie
-        ? { cookie: ctx.req.headers.cookie }
-        : undefined,
-    }
-    const { data } = await api.getMe(option)
+    const { data } = await api.getMe(requestOption(ctx))
     userName = data.name
   } catch (error) {
     const err = error as AxiosError


### PR DESCRIPTION
とりあえず開発環境用の暫定の対処です

ヘッダーの「Dev Login」ボタンをクリックすると、Cookieが付与されてログインが必要なAPIが叩けるようになります
<img width="228" alt="image" src="https://user-images.githubusercontent.com/50443000/174423633-243981cd-2cb7-45fd-86fb-2f6cb44758b0.png">
<img width="547" alt="image" src="https://user-images.githubusercontent.com/50443000/174423684-fbc4565c-5824-40ba-a2bd-b1d69bfe856d.png">

ログアウトはブラウザのCookieを削除するのでお願いします


Next.jsのサーバーサイドレンダリングを使う関係で、axiosでのリクエスト時にCookieをちゃんと受け渡す必要が発生しています
とりあえずこんな感じで書いてもらえばOKです
https://github.com/dacq-trap/dacq/blob/86a2ceae81c71d31d7a7485ab7d83be227cb6bfe/client/src/pages/index.tsx#L6
https://github.com/dacq-trap/dacq/blob/86a2ceae81c71d31d7a7485ab7d83be227cb6bfe/client/src/pages/index.tsx#L29-L35
もっといいやり方が見つかったら対応します