### PR TITLE
postOauthCodeからsecurityの項目を削除

### DIFF
--- a/schema/openapi/paths/oauth/code.yaml
+++ b/schema/openapi/paths/oauth/code.yaml
@@ -4,8 +4,6 @@ post:
     入手したOAuthコードを送信してログインします。  
     送信されたコードから入手したアクセストークンはサーバーに保存されます。
   operationId: postOauthCode
-  security:
-    - cookieAuth: []
   tags:
     - OAuth
   requestBody:


### PR DESCRIPTION
このレスポンスでCookieが付与されるので、postOauthCodeはsecurityの項目がいらないと認識しています
あってるかな？